### PR TITLE
Removes misleading `EnsureDeleted` calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,17 +32,19 @@ Mainly there are three available customizations at the moment:
 public void SaveChanges_ShouldCreateCustomerRecord()
 {
     var fixture = new Fixture().Customize(new InMemoryContextCustomization());
-    using var context = fixture.Create<TestDbContext>();
-    context.Database.EnsureCreated();
+    using (var context = fixture.Create<TestDbContext>())
+    {
+        context.Database.EnsureCreated();
 
-    context.Customers.Add(new Customer("John Doe"));
-    context.SaveChanges();
+        context.Customers.Add(new Customer("John Doe"));
+        context.SaveChanges();
 
-    context.Customers.Should().Contain(x => x.Name == "John Doe");
-
-    context.Database.EnsureDeleted();
+        context.Customers.Should().Contain(x => x.Name == "John Doe");
+    }
 }
+```
 
+```csharp
 [Theory]
 [AutoDomainDataWithInMemoryContext]
 public async Task SaveChangesAsync_ShouldCreateCustomerRecord(TestDbContext context)
@@ -55,8 +57,6 @@ public async Task SaveChangesAsync_ShouldCreateCustomerRecord(TestDbContext cont
         await context.SaveChangesAsync();
 
         context.Customers.Should().Contain(x => x.Name == "Jane Smith");
-
-        await context.Database.EnsureDeletedAsync();
     }
 }
 ```
@@ -86,8 +86,6 @@ public void Customize_ShouldProvideSqliteContext([Frozen] SqliteConnection conne
         context.SaveChanges();
 
         context.Orders.Should().Contain(x => x.CustomerId == customer.Id && x.ItemId == item.Id);
-
-        context.Database.EnsureDeleted();
     }
 }
 ```

--- a/src/EntityFrameworkCore.AutoFixture.Tests/InMemory/InMemoryCustomizationTests.cs
+++ b/src/EntityFrameworkCore.AutoFixture.Tests/InMemory/InMemoryCustomizationTests.cs
@@ -22,8 +22,6 @@ namespace EntityFrameworkCore.AutoFixture.Tests.InMemory
             context.SaveChanges();
 
             context.Customers.Should().Contain(x => x.Name == "John Doe");
-
-            context.Database.EnsureDeleted();
         }
 
         [Theory]
@@ -38,8 +36,6 @@ namespace EntityFrameworkCore.AutoFixture.Tests.InMemory
                 await context.SaveChangesAsync();
 
                 context.Customers.Should().Contain(x => x.Name == "Jane Smith");
-
-                await context.Database.EnsureDeletedAsync();
             }
         }
     }

--- a/src/EntityFrameworkCore.AutoFixture.Tests/Sqlite/SqliteCustomizationTests.cs
+++ b/src/EntityFrameworkCore.AutoFixture.Tests/Sqlite/SqliteCustomizationTests.cs
@@ -28,8 +28,6 @@ namespace EntityFrameworkCore.AutoFixture.Tests.Sqlite
                 context.SaveChanges();
 
                 context.Orders.Should().Contain(x => x.CustomerId == customer.Id && x.ItemId == item.Id);
-
-                context.Database.EnsureDeleted();
             }
         }
     }


### PR DESCRIPTION
Removes misleading `EnsureDeleted` calls from unit-tests and documentation