### PR TITLE
Implements tests for the optionsbuilder generic build method

### DIFF
--- a/src/EntityFrameworkCore.AutoFixture.Tests/InMemory/InMemoryOptionsBuilderTests.cs
+++ b/src/EntityFrameworkCore.AutoFixture.Tests/InMemory/InMemoryOptionsBuilderTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using AutoFixture;
 using AutoFixture.Idioms;
 using AutoFixture.Xunit2;
@@ -6,6 +7,7 @@ using EntityFrameworkCore.AutoFixture.InMemory;
 using EntityFrameworkCore.AutoFixture.Tests.Common.Persistence;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure.Internal;
 using Xunit;
 
 namespace EntityFrameworkCore.AutoFixture.Tests.InMemory
@@ -56,6 +58,53 @@ namespace EntityFrameworkCore.AutoFixture.Tests.InMemory
             var members = typeof(InMemoryOptionsBuilder).GetConstructors();
 
             assertion.Verify(members);
+        }
+
+        [Theory]
+        [AutoData]
+        public void GenericBuild_ShouldCreateDbContextOptions_WithInMemoryExtension(InMemoryOptionsBuilder builder)
+        {
+            var actual = builder.Build<TestDbContext>();
+
+            actual.Extensions.Should().Contain(x => x.GetType() == typeof(InMemoryOptionsExtension));
+        }
+
+        [Theory]
+        [AutoData]
+        public void GenericBuild_ShouldCreateDbContextOptions_WithInMemoryExtension_WithName(string expected)
+        {
+
+            var extension = new InMemoryOptionsBuilder(expected)
+                .Build<TestDbContext>()
+                .Extensions
+                .Single(x => x.GetType() == typeof(InMemoryOptionsExtension))
+                .As<InMemoryOptionsExtension>();
+
+            extension.StoreName.Should().Be(expected);
+        }
+
+        [Theory]
+        [AutoData]
+        public void Build_ShouldCreateDbContextOptions_WithInMemoryExtension(InMemoryOptionsBuilder builder)
+        {
+            var actual = builder.Build(typeof(TestDbContext)).As<DbContextOptions<TestDbContext>>();
+
+            actual.Extensions.Should().Contain(x => x.GetType() == typeof(InMemoryOptionsExtension));
+        }
+
+        [Theory]
+        [AutoData]
+        public void Build_ShouldCreateDbContextOptions_WithInMemoryExtension_WithName(string expected)
+        {
+
+            var extension = new InMemoryOptionsBuilder(expected)
+                .Build(typeof(TestDbContext))
+                .As<DbContextOptions<TestDbContext>>()
+                .Extensions
+                .Single(x => x.GetType() == typeof(InMemoryOptionsExtension))
+                .As<InMemoryOptionsExtension>();
+
+            extension.StoreName.Should().Be(expected);
         }
 
         private abstract class AbstractDbContext : DbContext { }

--- a/src/EntityFrameworkCore.AutoFixture/Common/OptionsBuilder.cs
+++ b/src/EntityFrameworkCore.AutoFixture/Common/OptionsBuilder.cs
@@ -6,7 +6,7 @@ namespace EntityFrameworkCore.AutoFixture.Common
 {
     public abstract class OptionsBuilder : IOptionsBuilder
     {
-        protected abstract DbContextOptions<TContext> Build<TContext>() where TContext : DbContext;
+        public abstract DbContextOptions<TContext> Build<TContext>() where TContext : DbContext;
 
         public virtual object Build(Type type)
         {
@@ -20,7 +20,7 @@ namespace EntityFrameworkCore.AutoFixture.Common
                 throw new ArgumentException($"The context type should be a non-abstract class inherited from {nameof(DbContext)}");
             }
 
-            var methods = GetType().GetMethods(BindingFlags.NonPublic | BindingFlags.Instance);
+            var methods = GetType().GetMethods(BindingFlags.Public | BindingFlags.Instance);
 
             var genericConfigureMethod = Array
                 .Find(methods, m => m.Name == nameof(Build) && m.IsGenericMethodDefinition)

--- a/src/EntityFrameworkCore.AutoFixture/InMemory/InMemoryOptionsBuilder.cs
+++ b/src/EntityFrameworkCore.AutoFixture/InMemory/InMemoryOptionsBuilder.cs
@@ -19,7 +19,7 @@ namespace EntityFrameworkCore.AutoFixture.InMemory
 
         public string DatabaseName { get; }
 
-        protected override DbContextOptions<TContext> Build<TContext>() => new DbContextOptionsBuilder<TContext>()
+        public override DbContextOptions<TContext> Build<TContext>() => new DbContextOptionsBuilder<TContext>()
             .UseInMemoryDatabase(DatabaseName)
             .Options;
     }

--- a/src/EntityFrameworkCore.AutoFixture/Sqlite/SqliteOptionsBuilder.cs
+++ b/src/EntityFrameworkCore.AutoFixture/Sqlite/SqliteOptionsBuilder.cs
@@ -15,7 +15,7 @@ namespace EntityFrameworkCore.AutoFixture.Sqlite
 
         public SqliteConnection Connection { get; }
 
-        protected override DbContextOptions<TContext> Build<TContext>() => new DbContextOptionsBuilder<TContext>()
+        public override DbContextOptions<TContext> Build<TContext>() => new DbContextOptionsBuilder<TContext>()
             .UseSqlite(Connection)
             .Options;
     }


### PR DESCRIPTION
- Makes the `OptionsBuilder.Build<TContext>()` method public
- Implements tests that asserts in-memory provider is used
- Implements tests that asserts SQLite provider is used